### PR TITLE
Better bug fix #78 #80

### DIFF
--- a/src/js/animsition.js
+++ b/src/js/animsition.js
@@ -89,12 +89,16 @@
 
           if(options.timeout) __.addTimer.call(_this);
 
-          $window.on('load.' + namespace + ' pageshow.' + namespace, function() {
+          $window.on('load.' + namespace, function() {
             if(__.settings.timer) clearTimeout(__.settings.timer);
             __.in.call(_this);
           });
 
-          if(!options.onLoadEvent) $window.off('load.' + namespace + ' pageshow.' + namespace);
+          $window.on('pageshow.' + namespace, function(event) {
+            if(event.originalEvent.persisted) __.in.call(_this);
+          });
+
+          if(!options.onLoadEvent) $window.off('load.' + namespace);
 
           // Firefox back button issue #4
           $window.on('unload.' + namespace, function() { });

--- a/src/js/animsition.js
+++ b/src/js/animsition.js
@@ -208,6 +208,11 @@
 
       if(options.loading) __.removeLoading.call(_this);
 
+      var outClass = $this.data(namespace).outClass;
+      if (outClass) {
+        $this.removeClass(outClass);
+      }
+
       if(overlayMode) {
         __.inOverlay.call(_this, inClass, inDuration);
       } else {
@@ -261,6 +266,8 @@
       var outClass = __.animationCheck.call(_this, isOutClass, true, false);
       var outDuration = __.animationCheck.call(_this, isOutDuration, false, false);
       var overlayMode = __.optionCheck.call(_this, options);
+
+      $this.data(namespace).outClass = outClass;
 
       if(overlayMode) {
         __.outOverlay.call(_this, outClass, outDuration, url);

--- a/src/js/animsition.js
+++ b/src/js/animsition.js
@@ -89,16 +89,16 @@
 
           if(options.timeout) __.addTimer.call(_this);
 
-          $window.on('load.' + namespace, function() {
-            if(__.settings.timer) clearTimeout(__.settings.timer);
-            __.in.call(_this);
-          });
+          if(options.onLoadEvent) {
+            $window.on('load.' + namespace, function() {
+              if(__.settings.timer) clearTimeout(__.settings.timer);
+              __.in.call(_this);
+            });
+          }
 
           $window.on('pageshow.' + namespace, function(event) {
             if(event.originalEvent.persisted) __.in.call(_this);
           });
-
-          if(!options.onLoadEvent) $window.off('load.' + namespace);
 
           // Firefox back button issue #4
           $window.on('unload.' + namespace, function() { });
@@ -146,7 +146,7 @@
 
       __.settings.timer = setTimeout(function(){
         __.in.call(_this);
-        $(window).off('load.' + namespace + ' pageshow.' + namespace);
+        $(window).off('load.' + namespace);
       }, options.timeoutCountdown);
     },
 


### PR DESCRIPTION
This in my opinion is 100 times better than fix in patch-4.0.1 as this does not trigger a window refresh. On example pages maybe it looks more or less good but in real web sites doing a page refresh on every history back button is pretty ugly, especially on iOS.

This does not work with custom elements like overlays however, maybe a better way would be to save somewhere all DOM modifications in `out` method and in `in` method to revert them?

As I understand it will work only for elements that have an `in` animation on the same elements that have an `out` one, because this will trigger reverting classes.